### PR TITLE
Created contexts for json-ld 1.1

### DIFF
--- a/contexts/evaluation.json
+++ b/contexts/evaluation.json
@@ -1,0 +1,33 @@
+{ 
+      "@context": {
+      "sotw" : "https://w3id.org/force/sotw#",
+      "EvaluationRequest" : "https://w3id.org/force/sotw#EvaluationRequest",
+      "evaluatedAction" : {
+      	"@id" : "https://w3id.org/force/sotw#evaluatedAction",
+        "@type" : "@id"
+      },
+      "evaluatedParty" : {
+      	"@id" : "https://w3id.org/force/sotw#evaluatedParty",
+      	"@type" : "@id"
+      },
+      "evaluatedTarget" : {
+      	"@id" : "https://w3id.org/force/sotw#evaluatedTarget",
+      	"@type" : "@id"
+      },
+      "requestParameters" : {
+      	"@id" : "https://w3id.org/force/sotw#requestParameter",
+        "@context" : {
+          "RequestParameter" : "sotw:RequestParameter",
+          "DataFeature" : "sotw:DataFeature",
+           "value" : {
+            "@id" : "https://w3id.org/force/sotw#value",
+             "@type" : "xsd:string"
+          },
+          "describesFeature" : {
+          	"@id" : "https://w3id.org/force/sotw#describesFeature",
+            "@type" : "@id"
+          }
+        }
+       }
+      } 
+    }

--- a/contexts/sotw.json
+++ b/contexts/sotw.json
@@ -1,0 +1,16 @@
+{
+       "@context" : {
+       "sotw" : "https://w3id.org/force/sotw#",
+       "SotW" : "sotw:SotW",
+       "context" :{
+            "@id" : "sotw:context",
+            "@context" : {
+              "conditionId" : {
+                "@id" : "sotw:conditionId",
+                "@type" : "@id"
+              }
+            }
+             
+       }
+      }
+    }


### PR DESCRIPTION
Two @context files are created in this PR, one for the evaluation requests and the other for representing the sotw.